### PR TITLE
fix: render author as string in post meta

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -3,8 +3,7 @@ languageCode: en-us
 title: florianschick.com
 theme: ["PaperMod"]
 params:
-  author:
-    name: Florian Schick
+  author: Florian Schick
   ShowAllPagesInArchive: true
   ShowCodeCopyButtons: true
   homeInfoParams:


### PR DESCRIPTION
## Summary
- Post headlines were showing `April 30, 2026 · map[name:Florian Schick]` because `params.author` in `hugo.yaml` was configured as a map.
- PaperMod's `layouts/partials/author.html` only branches on string and string-slice types — anything else falls through to a raw print, which Go formats as `map[...]`.
- Flatten `params.author` to a plain string so the existing string branch handles it cleanly.

## Test plan
- [x] `hugo server` locally and load `/posts/atlantis-ai-plan-summary/` — meta line now reads `April 30, 2026 · Florian Schick`.
- [ ] Reviewer spot-checks any other post page after deploy to confirm the byline renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)