### PR TITLE
content: add AI disclaimer to home intro

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -21,6 +21,9 @@ params:
 
       **Writing helps me think** and maybe some of it helps you too.
 
+
+      **A note on AI:** I use it to help shape these posts into something readable. The ideas, projects, and opinions are mine — I'm just bad at long-form writing, and AI gets me from rough notes to actual paragraphs without eating an entire weekend.
+
   socialIcons:
     - name: github
       title: View Source on Github


### PR DESCRIPTION
## Summary
- Add a short, transparent note about AI use to the home intro (`homeInfoParams.Content` in `hugo.yaml`).
- Sits alongside the existing about-style copy since there is no dedicated `/about/` page.
- Wording is intentionally plain and first-person: ideas and opinions stay mine, AI helps shape the prose.

## Test plan
- [x] `hugo server` locally and confirm the new paragraph renders on `/`.
- [ ] Reviewer eyeballs the tone and pacing on the home page after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)